### PR TITLE
fix: dont autoplay fullscreen on ios devices

### DIFF
--- a/src/app/LightboxStoryPhoto.js
+++ b/src/app/LightboxStoryPhoto.js
@@ -697,7 +697,9 @@ const LightboxStoryPhoto = ({
               </div>
             )}
             <Video
+              playsInline
               autoPlay
+              loop
               controls
               data-chq-video={activeStory.id}
               onPause={handleVideoStoryPause}


### PR DESCRIPTION
# Pull Request

## Description

Don't display the video stories on full screen for IOS devices

Fixes [(ticket link)](https://trello.com/c/07JfYHRR/3324-qa-bug-found-mobile-video-playback-comcast-brian)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Open the widget on an IOS device
- Verify the video stories are not being played at full screen
