### PR TITLE
fix: carousel arrows display when container overflow

### DIFF
--- a/src/app/StoriesSlider.js
+++ b/src/app/StoriesSlider.js
@@ -11,10 +11,10 @@ import justFirstName from "./utils/justFirstName";
 const TARGET_HEIGHT = "534px";
 const DEFAULT_HEIGHT = "400px";
 
-const getSlideLayout = (index, containerRef, sliderRef, stories) => {
+const getSlideLayout = (index, containerRef, sliderRef, stories, displayArrows) => {
   let percent = index * (100 / (stories.length));
   const left = index !== 0;
-  let right = index !== stories.length && stories.length > 4;
+  let right = index !== stories.length && displayArrows;
 
   const container = containerRef.current;
   const slider = sliderRef.current;
@@ -334,10 +334,11 @@ const StoriesSlider = ({ filters = {}, organizationId, organizationName, stories
   const [gaSessionId, setGaSessionId] = useState();
   const [fullWidth, setFullWidth] = useState(false);
   const [cardHeight, setCardHeight] = useState(defaultHeight);
+  const [displayArrows, setDisplayArrows] = useState(false);
 
   const containerRef = useRef(null);
   const sliderRef = useRef(null);
-  const slideLayout = getSlideLayout(index, containerRef, sliderRef, currentStories);
+  const slideLayout = getSlideLayout(index, containerRef, sliderRef, currentStories, displayArrows);
 
   useEffect(() => {
   if (containerRef.current) {
@@ -428,6 +429,13 @@ const StoriesSlider = ({ filters = {}, organizationId, organizationName, stories
       setCurrentStories(stories)
     }, [stories]
   );
+
+  useEffect(() => {
+    const containerDiv = containerRef.current;
+    if (containerDiv) {
+      setDisplayArrows(containerDiv.scrollWidth > containerDiv.clientWidth);
+    }
+  }, [containerRef.current]);
 
   useEffect(
     () => {


### PR DESCRIPTION
# Pull Request

## Description

Change the validation to hide or display the carousel arrows according to the container's overflow and not the storie's length.

Fixes [(ticket link)](https://trello.com/c/4qmmLS59/3451-carousel-arrows-with-less-than-4-stories)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Verify that the arrows are displaying when the stories overflow the container even if there's less than 4 stories