### PR TITLE
fix: display story creator name

### DIFF
--- a/src/app/LightboxStoryPhoto.js
+++ b/src/app/LightboxStoryPhoto.js
@@ -12,7 +12,7 @@ import defaultStyles from "../styles.json";
 import Subtitles from "./Subtitles";
 import LightboxImageSlider from "./LightboxImageSlider";
 import isTarget from "./utils/isTarget";
-import justFirstName from "./utils/justFirstName";
+import displayCreatorName from "./utils/displayCreatorName";
 
 const GalleryLightboxWrapper = styled.div`
   border-radius: 0;
@@ -768,14 +768,14 @@ const LightboxStoryPhoto = ({
           {creator && (
             <GalleryLightBoxCreatorContainer>
               <Thumbnail
-                title={justFirstName(organizationName) ? creator.firstName : creator.name}
+                title={displayCreatorName(creator, organizationName)}
                 style={{ backgroundImage: `url("${creator.avatar.thumbUrl}")` }}
               />
               <div
                 style={{ marginLeft: "10px" }}
               >
                 <GalleryLightboxUploaderName organizationName={organizationName} >
-                  {justFirstName(organizationName) ? creator.firstName : creator.name}
+                  {displayCreatorName(creator, organizationName)}
                 </GalleryLightboxUploaderName>
                 <GalleryLightboxUploaderDate organizationName={organizationName} >
                   {creator.title}


### PR DESCRIPTION
# Pull Request

## Description

Display the creator name when opening a story.

Fixes [(ticket link)](https://trello.com/c/wPGXaSJf/3838-rtx-widget-display-first-name-and-last-names-first-letter)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Go to the widget
- Open a story and verify that the creator name is being displayed properly according to the organization