### PR TITLE
feat: reference staging environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@ body {
         y.src = "main.js";
         y.onload = function () { CHQ(c, h, q, z) };
         document.getElementsByTagName("head")[0].appendChild(y);
-      }("#main", "null", {"i":[],"d":[],"l":[],"s":[],"co":[],"cy":[],"m":[],"r":[],"v":[],"u":[],"sp":[],"t":[],"lang":"pt","org": 325184378 })
+      }("#main", "null", {"i":[],"d":[],"l":[],"s":[],"co":[],"cy":[],"m":[],"r":[],"v":[],"u":[],"sp":[],"t":[],"lang":"pt","org": 325184378, "env": "production" })
       // local bot token "mP3nYfCozjfUBF6EWvHkLzMn"
       // filters example:  {i: [948961931], s: [1004640656]}
     </script>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -7,6 +7,7 @@ import Failure from "./Failure";
 import CHQStory from "../lib/CHQStory";
 import StoriesSlider from "./StoriesSlider";
 import EmptySlider from "./EmptySlider";
+import { configure } from "@culturehq/client";
 
 /*
 import { configure, skipPreflightChecks } from "@culturehq/client";
@@ -70,6 +71,18 @@ const queryToOptions = queryString => {
   };
 };
 
+const configureEnv = env => {
+  if (env === "test") {
+    configure(
+      {
+        apiHost: "https://api-staging.culturehq.com",
+        awsAccessKeyId: "AKIA2OD42LXEEQNIKOWR",
+        signerURL: "https://0f8wfhpcb9.execute-api.us-west-2.amazonaws.com/production/signature",
+        uploadBucket: "https://culturehq-direct-uploads-staging.s3-us-west-2.amazonaws.com"
+      });
+  }
+};
+
 class App extends Component {
   constructor(props) {
     super(props);
@@ -86,6 +99,9 @@ class App extends Component {
   componentDidMount() {
     this.componentIsMounted = true;
     const { filters } = this.props;
+    const { env } = filters;
+
+    configureEnv(env);
 
     return makeGet(
       "/landing_pages/stories",


### PR DESCRIPTION
# Pull Request

## Description

Use staging environment for `Story Slider` and `Single Story Slider`.

Fixes [(ticket link)](https://trello.com/c/nsmB6yG5/3908-qa-bug-story-slider-and-single-story-slider-referencing-production-instead-of-staging-widget)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Make sure you're on the staging environment
- On the `Admin Dashboard` go to `CulturePages | Embed`.
- Select `Story Slider` or `Single Story Slider`.
- Generate or inspect the embed HTML code.
- Verify that the code references `Staging` and not `Production`.
